### PR TITLE
Remove arm extend / retract actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,11 +222,10 @@ Terra comes with two types of maps: foundations and trenches. Foundations are pr
 ## Observation Space 🔍
 The agent in Terra perceives the environment through a rich observation space that provides comprehensive information about the state of the world and the agent itself. The observation is a dictionary with the following components:
 
-- **agent_states**: A 6-dimensional vector containing:
+- **agent_states**: A 5-dimensional vector containing:
   - Position of the base (x, y coordinates)
   - Base rotation angle
   - Cabin rotation angle
-  - Arm extension
   - Whether the agent is loaded with dirt (0 or 1)
 
 - **Local Maps**: The agent has access to local maps representing different aspects of the environment from the agent's perspective:

--- a/terra/actions.py
+++ b/terra/actions.py
@@ -22,9 +22,7 @@ class TrackedActionType(ActionType):
     ANTICLOCK = 3
     CABIN_CLOCK = 4
     CABIN_ANTICLOCK = 5
-    EXTEND_ARM = 6
-    RETRACT_ARM = 7
-    DO = 8
+    DO = 6
 
 
 Action = NamedTuple
@@ -73,14 +71,6 @@ class TrackedAction(Action):
         )
 
     @classmethod
-    def extend_arm(cls):
-        return cls.new(jnp.full((1,), TrackedActionType.EXTEND_ARM, dtype=IntLowDim))
-
-    @classmethod
-    def retract_arm(cls):
-        return cls.new(jnp.full((1,), TrackedActionType.RETRACT_ARM, dtype=IntLowDim))
-
-    @classmethod
     def do(cls):
         return cls.new(jnp.full((1,), TrackedActionType.DO, dtype=IntLowDim))
 
@@ -96,7 +86,7 @@ class TrackedAction(Action):
 
     @staticmethod
     def get_num_actions():
-        return 9
+        return 7
 
 
 class WheeledActionType(ActionType):
@@ -113,9 +103,7 @@ class WheeledActionType(ActionType):
     ANTICLOCK_BACKWARD = 5
     CABIN_CLOCK = 6
     CABIN_ANTICLOCK = 7
-    EXTEND_ARM = 8
-    RETRACT_ARM = 9
-    DO = 10
+    DO = 8
 
 
 class WheeledAction(Action):
@@ -175,14 +163,6 @@ class WheeledAction(Action):
         )
 
     @classmethod
-    def extend_arm(cls):
-        return cls.new(jnp.full((1,), WheeledActionType.EXTEND_ARM, dtype=IntLowDim))
-
-    @classmethod
-    def retract_arm(cls):
-        return cls.new(jnp.full((1,), WheeledActionType.RETRACT_ARM, dtype=IntLowDim))
-
-    @classmethod
     def do(cls):
         return cls.new(jnp.full((1,), WheeledActionType.DO, dtype=IntLowDim))
 
@@ -198,4 +178,4 @@ class WheeledAction(Action):
 
     @staticmethod
     def get_num_actions():
-        return 11
+        return 9

--- a/terra/agent.py
+++ b/terra/agent.py
@@ -25,7 +25,6 @@ class AgentState(NamedTuple):
     pos_base: IntMap
     angle_base: IntLowDim
     angle_cabin: IntLowDim
-    arm_extension: IntLowDim
     loaded: IntLowDim
 
 
@@ -66,7 +65,6 @@ class Agent(NamedTuple):
             pos_base=pos_base,
             angle_base=angle_base,
             angle_cabin=jnp.full((1,), 0, dtype=IntLowDim),
-            arm_extension=jnp.full((1,), 0, dtype=IntLowDim),
             loaded=jnp.full((1,), 0, dtype=IntLowDim),
         )
 

--- a/terra/config.py
+++ b/terra/config.py
@@ -42,7 +42,6 @@ class ImmutableAgentConfig(NamedTuple):
     dimensions: ExcavatorDims = ExcavatorDims()
     angles_base: int = 4
     angles_cabin: int = 8
-    max_arm_extension: int = 1  # numbering starts from 0 (0 is the closest level)
 
 
 class AgentConfig(NamedTuple):
@@ -50,7 +49,6 @@ class AgentConfig(NamedTuple):
 
     angles_base: int = ImmutableAgentConfig().angles_base
     angles_cabin: int = ImmutableAgentConfig().angles_cabin
-    max_arm_extension: int = ImmutableAgentConfig().max_arm_extension
 
     move_tiles: int = 6  # number of tiles of progress for every move action
     #  Note: move_tiles is also used as radius of excavation

--- a/terra/env.py
+++ b/terra/env.py
@@ -237,7 +237,6 @@ class TerraEnv(NamedTuple):
                 state.agent.agent_state.pos_base,  # pos_base is encoded in traversability_mask
                 state.agent.agent_state.angle_base,
                 state.agent.agent_state.angle_cabin,
-                state.agent.agent_state.arm_extension,
                 state.agent.agent_state.loaded,
             ]
         )
@@ -432,7 +431,7 @@ class TerraEnvBatch:
             - value: the tuple representing the shape of the input feature
         """
         return {
-            "agent_states": (6,),
+            "agent_states": (5,),
             "local_map_action_neg": (self.batch_cfg.agent.angles_cabin,),
             "local_map_action_pos": (self.batch_cfg.agent.angles_cabin,),
             "local_map_target_neg": (self.batch_cfg.agent.angles_cabin,),

--- a/terra/env.py
+++ b/terra/env.py
@@ -433,30 +433,12 @@ class TerraEnvBatch:
         """
         return {
             "agent_states": (6,),
-            "local_map_action_neg": (
-                self.batch_cfg.agent.angles_cabin,
-                self.batch_cfg.agent.max_arm_extension + 1,
-            ),
-            "local_map_action_pos": (
-                self.batch_cfg.agent.angles_cabin,
-                self.batch_cfg.agent.max_arm_extension + 1,
-            ),
-            "local_map_target_neg": (
-                self.batch_cfg.agent.angles_cabin,
-                self.batch_cfg.agent.max_arm_extension + 1,
-            ),
-            "local_map_target_pos": (
-                self.batch_cfg.agent.angles_cabin,
-                self.batch_cfg.agent.max_arm_extension + 1,
-            ),
-            "local_map_dumpability": (
-                self.batch_cfg.agent.angles_cabin,
-                self.batch_cfg.agent.max_arm_extension + 1,
-            ),
-            "local_map_obstacles": (
-                self.batch_cfg.agent.angles_cabin,
-                self.batch_cfg.agent.max_arm_extension + 1,
-            ),
+            "local_map_action_neg": (self.batch_cfg.agent.angles_cabin,),
+            "local_map_action_pos": (self.batch_cfg.agent.angles_cabin,),
+            "local_map_target_neg": (self.batch_cfg.agent.angles_cabin,),
+            "local_map_target_pos": (self.batch_cfg.agent.angles_cabin,),
+            "local_map_dumpability": (self.batch_cfg.agent.angles_cabin,),
+            "local_map_obstacles": (self.batch_cfg.agent.angles_cabin,),
             "action_map": (
                 self.batch_cfg.maps.max_width,
                 self.batch_cfg.maps.max_height,

--- a/terra/state.py
+++ b/terra/state.py
@@ -723,8 +723,6 @@ class State(NamedTuple):
 
         # Fixed middle-point arm extension (halfway between 0 and 1)
         fixed_extension = 0.5
-
-        # Calculate the middle range between what would be arm_extension=0 and arm_extension=1
         r_min = fixed_extension * dig_portion_radius * tile_size + min_distance_from_agent
         r_max = (fixed_extension + 1) * dig_portion_radius * tile_size + min_distance_from_agent
         theta_max = np.pi / self.env_cfg.agent.angles_cabin

--- a/terra/state.py
+++ b/terra/state.py
@@ -1566,15 +1566,6 @@ class State(NamedTuple):
             == self.agent.agent_state.angle_cabin
         )
 
-        # extend arm
-        bool_extend_arm = ~(
-            self.agent.agent_state.arm_extension[0]
-            == self.env_cfg.agent.max_arm_extension
-        )
-
-        # retract arm
-        bool_retract_arm = ~(self.agent.agent_state.arm_extension[0] == 0)
-
         # do
         new_state = self._handle_do()
         bool_do = ~jnp.all(
@@ -1589,8 +1580,6 @@ class State(NamedTuple):
                 bool_anticlock,
                 bool_cabin_clock,
                 bool_cabin_anticlock,
-                bool_extend_arm,
-                bool_retract_arm,
                 bool_do,
                 0,  # dummy
                 0,  # dummy
@@ -1652,15 +1641,6 @@ class State(NamedTuple):
             == self.agent.agent_state.angle_cabin
         )
 
-        # extend arm
-        bool_extend_arm = ~(
-            self.agent.agent_state.arm_extension[0]
-            == self.env_cfg.agent.max_arm_extension
-        )
-
-        # retract arm
-        bool_retract_arm = ~(self.agent.agent_state.arm_extension[0] == 0)
-
         # do
         new_state = self._handle_do()
         bool_do = ~jnp.all(
@@ -1677,8 +1657,6 @@ class State(NamedTuple):
                 bool_move_anticlock_backward,
                 bool_cabin_clock,
                 bool_cabin_anticlock,
-                bool_extend_arm,
-                bool_retract_arm,
                 bool_do,
             ],
             dtype=jnp.bool_,

--- a/terra/state.py
+++ b/terra/state.py
@@ -796,9 +796,7 @@ class State(NamedTuple):
         Returns:
             - dig_mask: (N, ) Array of bools, where True means dig here
         """
-        dig_dump_mask_cyl = self._get_dig_dump_mask_cyl(
-            map_cyl_coords, self.agent.agent_state.arm_extension
-        )
+        dig_dump_mask_cyl = self._get_dig_dump_mask_cyl(map_cyl_coords)
 
         agent_width = self.env_cfg.agent.width * self.env_cfg.tile_size
         agent_height = self.env_cfg.agent.height * self.env_cfg.tile_size

--- a/terra/state.py
+++ b/terra/state.py
@@ -748,9 +748,7 @@ class State(NamedTuple):
         cabin_angle = self._get_cabin_angle_rad()
         return wrap_angle_rad(base_angle + cabin_angle)
 
-    def _get_dig_dump_mask_cyl(
-        self, map_cyl_coords: Array, arm_extension: Array
-    ) -> Array:
+    def _get_dig_dump_mask_cyl(self, map_cyl_coords: Array) -> Array:
         """
         Note: the map is assumed to be local -> the area to dig is in front of us.
 
@@ -767,18 +765,18 @@ class State(NamedTuple):
         )
         min_distance_from_agent = tile_size * max_agent_dim
 
-        r_max = (
-            arm_extension + 1
-        ) * dig_portion_radius * tile_size + min_distance_from_agent
-        r_min = arm_extension * dig_portion_radius * tile_size + min_distance_from_agent
+        # Fixed middle-point arm extension (halfway between 0 and 1)
+        fixed_extension = 0.5
 
+        # Calculate the middle range between what would be arm_extension=0 and arm_extension=1
+        r_min = fixed_extension * dig_portion_radius * tile_size + min_distance_from_agent
+        r_max = (fixed_extension + 1) * dig_portion_radius * tile_size + min_distance_from_agent
         theta_max = np.pi / self.env_cfg.agent.angles_cabin
         theta_min = -theta_max
 
         dig_mask_r = jnp.logical_and(
             map_cyl_coords[0] >= r_min, map_cyl_coords[0] <= r_max
         )
-
         dig_mask_theta = jnp.logical_and(
             map_cyl_coords[1] >= theta_min, map_cyl_coords[1] <= theta_max
         )

--- a/terra/state.py
+++ b/terra/state.py
@@ -36,8 +36,6 @@ class State(NamedTuple):
         - Move Backward
         - Rotate Clockwise
         - Rotate Anticlockwise
-        - Extend Arm
-        - Retract Arm
         - Do
     - Wheeled Agent
         - Move Forward
@@ -48,8 +46,6 @@ class State(NamedTuple):
         - Move Anticlockwise Backward
         - Rotate Cabin Clockwise
         - Rotate Cabin Anticlockwise
-        - Extend Arm
-        - Retract Arm
         - Do
     """
 

--- a/terra/state.py
+++ b/terra/state.py
@@ -128,8 +128,6 @@ class State(NamedTuple):
             self._handle_anticlock,
             self._handle_cabin_clock,
             self._handle_cabin_anticlock,
-            self._handle_extend_arm,
-            self._handle_retract_arm,
             self._handle_do,
             # Wheeled
             self._handle_move_forward,
@@ -140,11 +138,9 @@ class State(NamedTuple):
             self._handle_move_anticlock_backward,
             self._handle_cabin_clock,
             self._handle_cabin_anticlock,
-            self._handle_extend_arm,
-            self._handle_retract_arm,
             self._handle_do,
         ]
-        cumulative_len = jnp.array([0, 9], dtype=IntLowDim)
+        cumulative_len = jnp.array([0, 7], dtype=IntLowDim)
         offset_idx = (cumulative_len @ jax.nn.one_hot(action.type[0], 2)).astype(
             IntLowDim
         )
@@ -648,46 +644,6 @@ class State(NamedTuple):
             valid_chain,
             lambda: s2,
             lambda: self,
-        )
-
-    def _handle_extend_arm(self) -> "State":
-        new_arm_extension = jnp.min(
-            jnp.array(
-                [
-                    self.agent.agent_state.arm_extension + 1,
-                    jnp.full(
-                        (1,),
-                        fill_value=self.env_cfg.agent.max_arm_extension,
-                        dtype=IntLowDim,
-                    ),
-                ]
-            ),
-            axis=0,
-        )
-        return self._replace(
-            agent=self.agent._replace(
-                agent_state=self.agent.agent_state._replace(
-                    arm_extension=new_arm_extension
-                )
-            )
-        )
-
-    def _handle_retract_arm(self) -> "State":
-        new_arm_extension = jnp.max(
-            jnp.array(
-                [
-                    self.agent.agent_state.arm_extension - 1,
-                    jnp.full((1,), fill_value=0, dtype=IntLowDim),
-                ]
-            ),
-            axis=0,
-        )
-        return self._replace(
-            agent=self.agent._replace(
-                agent_state=self.agent.agent_state._replace(
-                    arm_extension=new_arm_extension
-                )
-            )
         )
 
     @staticmethod

--- a/terra/viz/main_manual.py
+++ b/terra/viz/main_manual.py
@@ -9,8 +9,6 @@ from pygame.locals import (
     K_RIGHT,
     K_a,
     K_d,
-    K_e,
-    K_r,
     K_i,
     K_o,
     K_k,
@@ -76,10 +74,6 @@ def main():
                     action = action_type.cabin_anticlock()
                 elif event.key == K_d:
                     action = action_type.cabin_clock()
-                elif event.key == K_e:
-                    action = action_type.extend_arm()
-                elif event.key == K_r:
-                    action = action_type.retract_arm()
                 elif event.key == K_o:
                     action = action_type.clock_forward()
                 elif event.key == K_k:

--- a/terra/wrappers.py
+++ b/terra/wrappers.py
@@ -111,14 +111,8 @@ class LocalMapWrapper:
         local_cartesian_masks = jax.vmap(lambda map: state._get_dig_dump_mask_cyl(map))(
             possible_maps_cyl_coords
         )
-
-        # Go from mask to masked height map to local cylindrical cumsum(s)
         local_cyl_height_map = jax.vmap(
-            jax.vmap(
-                lambda x: (
-                    (map_to_wrap) * x.reshape(state.world.width, state.world.height)
-                ).sum()
-            )
+            lambda x: map_to_wrap * x.reshape(state.world.height, state.world.width)
         )(local_cartesian_masks)
 
         # Roll it to bring it back in agent view

--- a/terra/wrappers.py
+++ b/terra/wrappers.py
@@ -69,8 +69,8 @@ class LocalMapWrapper:
         """
         Encodes the local map in the GridWorld.
 
-        The local map is is (angles_cabin, max_arm_extension), and encodes
-        the cumulative sum of tiles to dig in the area spanned by the cyilindrical tile.
+        The local map is of dim angles_cabin, and encodes the cumulative
+        sum of tiles to dig in the area spanned by the cyilindrical tile.
         """
         current_pos_idx = state._get_current_pos_vector_idx(
             pos_base=state.agent.agent_state.pos_base,
@@ -94,7 +94,6 @@ class LocalMapWrapper:
             EnvConfig().agent.angles_cabin
         )  # TODO: make state.env_cfg work instead of recreating the object every time
         arm_angles_ints = jnp.arange(angles_cabin)
-        arm_extensions = jnp.arange(EnvConfig().agent.max_arm_extension + 1)
         arm_angles_rads = jax.vmap(
             lambda angle: angle_idx_to_rad(angle, EnvConfig().agent.angles_cabin)
         )(arm_angles_ints)
@@ -109,13 +108,9 @@ class LocalMapWrapper:
             possible_maps_local_coords_arm
         )  # (n_angles x 2 x width*height)
 
-        local_cartesian_masks = jax.vmap(
-            lambda map: jax.vmap(
-                lambda arm_extension: state._get_dig_dump_mask_cyl(map, arm_extension)
-            )(arm_extensions)
-        )(
+        local_cartesian_masks = jax.vmap(lambda map: state._get_dig_dump_mask_cyl(map))(
             possible_maps_cyl_coords
-        )  # (n_angles x n_arm_extensions x width*height)
+        )
 
         # Go from mask to masked height map to local cylindrical cumsum(s)
         local_cyl_height_map = jax.vmap(

--- a/terra/wrappers.py
+++ b/terra/wrappers.py
@@ -111,8 +111,9 @@ class LocalMapWrapper:
         local_cartesian_masks = jax.vmap(lambda map: state._get_dig_dump_mask_cyl(map))(
             possible_maps_cyl_coords
         )
+        map_to_wrap_reshaped = map_to_wrap.reshape(state.world.height, state.world.width)
         local_cyl_height_map = jax.vmap(
-            lambda x: map_to_wrap * x.reshape(state.world.height, state.world.width)
+            lambda mask: (map_to_wrap_reshaped * mask.reshape(state.world.height, state.world.width)).sum()
         )(local_cartesian_masks)
 
         # Roll it to bring it back in agent view


### PR DESCRIPTION
Removes the `EXTEND_ARM` and `RETRACT_ARM` actions since:

1. They were not used by the RL agent.
2. Their functionality should be overtaken by excavating controller in the future anyway.
3. It simplifies both action and observation spaces.

The digging area is now placed in the middle of what it used to be for the retracted / extended state:

![image](https://github.com/user-attachments/assets/f127ccae-ccdf-469b-8937-33717f01a4aa)
