### PR TITLE
Remove dig map from observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,6 @@ The agent in Terra perceives the environment through a rich observation space th
   - **action_map**: Current state of the terrain across the entire map
   - **target_map**: Target digging profile across the entire map
   - **traversability_mask**: Areas where the agent can navigate
-  - **dig_map**: Preview of the dig/dump action result if executed
   - **dumpability_mask**: Areas where the agent can dump soil
   - **padding_mask**: Areas with obstacles
 

--- a/terra/agent.py
+++ b/terra/agent.py
@@ -39,6 +39,8 @@ class Agent(NamedTuple):
     width: int
     height: int
 
+    moving_dumped_dirt: bool
+
     @staticmethod
     def new(
         key: jax.random.PRNGKey,
@@ -73,7 +75,9 @@ class Agent(NamedTuple):
         width = env_cfg.agent.width
         height = env_cfg.agent.height
 
-        return Agent(agent_state=agent_state, width=width, height=height), key
+        moving_dumped_dirt = False
+
+        return Agent(agent_state=agent_state, width=width, height=height, moving_dumped_dirt=moving_dumped_dirt), key
 
 
 def _get_top_left_init_state(key: jax.random.PRNGKey, env_cfg: EnvConfig):

--- a/terra/config.py
+++ b/terra/config.py
@@ -107,8 +107,8 @@ class Rewards(NamedTuple):
             wheel_turn=-0.02,
             dig_wrong=-3.0,
             dump_wrong=-3.0,
-            dig_correct=0.4,
-            dump_correct=0.05,
+            dig_correct=0.3,
+            dump_correct=0.2,
             terminal_completed_tiles=0.0,
             terminal=100.0,
             normalizer=100.0,
@@ -176,8 +176,8 @@ class EnvConfig(NamedTuple):
     rewards: Rewards = Rewards.dense()
 
     apply_trench_rewards: bool = False
-    alignment_coefficient: float = -0.1
-    distance_coefficient: float = -0.05
+    alignment_coefficient: float = -0.08
+    distance_coefficient: float = -0.04
 
     curriculum: CurriculumConfig = CurriculumConfig()
 

--- a/terra/config.py
+++ b/terra/config.py
@@ -40,7 +40,7 @@ class ImmutableAgentConfig(NamedTuple):
     """
 
     dimensions: ExcavatorDims = ExcavatorDims()
-    angles_base: int = 24
+    angles_base: int = 12
     angles_cabin: int = 12
     max_wheel_angle: int = 3
     wheel_step: float = 10.0  # difference between next angles in discretization (in degrees)
@@ -107,8 +107,8 @@ class Rewards(NamedTuple):
             wheel_turn=-0.02,
             dig_wrong=-3.0,
             dump_wrong=-3.0,
-            dig_correct=0.3,
-            dump_correct=0.2,
+            dig_correct=0.1,
+            dump_correct=0.04,
             terminal_completed_tiles=0.0,
             terminal=100.0,
             normalizer=100.0,

--- a/terra/config.py
+++ b/terra/config.py
@@ -80,13 +80,12 @@ class Rewards(NamedTuple):
     wheel_turn: float
 
     dig_wrong: float  # dig where the target map is not negative (exclude case of positive action map -> moving dumped terrain)
-    dump_wrong: float  # given if loaded stayed the same
-    dump_no_dump_area: float  # given if dumps in an area that is not the dump area
+    dump_wrong: float  # given if loaded stayed the same or tried to dump in non-dumpable tile
 
     dig_correct: (
         float  # dig where the target map is negative, and not more than required
     )
-    dump_correct: float  # dump where the target map is positive, only if digged and not moved soil around
+    dump_correct: float  # dump where the target map is positive
 
     terminal: float  # given if the action map is the same as the target map where it matters (digged tiles)
 
@@ -106,11 +105,10 @@ class Rewards(NamedTuple):
             base_turn=-0.1,
             cabin_turn=-0.01,
             wheel_turn=-0.02,
-            dig_wrong=-0.3,
-            dump_wrong=-0.3,
-            dump_no_dump_area=-3.0,
-            dig_correct=3.0,
-            dump_correct=3.0,
+            dig_wrong=-3.0,
+            dump_wrong=-3.0,
+            dig_correct=0.4,
+            dump_correct=0.05,
             terminal_completed_tiles=0.0,
             terminal=100.0,
             normalizer=100.0,
@@ -131,7 +129,6 @@ class Rewards(NamedTuple):
     #         wheel_turn=-0.2,
     #         dig_wrong=-1.0,
     #         dump_wrong=0.0,
-    #         dump_no_dump_area=-3.0,
     #         dig_correct=1.0,
     #         dump_correct=1.0,
     #         terminal_completed_tiles=0.0,
@@ -153,7 +150,6 @@ class Rewards(NamedTuple):
             wheel_turn=-0.005,
             dig_wrong=-0.3,
             dump_wrong=-0.3,
-            dump_no_dump_area=0.0,
             dig_correct=0.0,
             dump_correct=0.0,
             terminal_completed_tiles=0.0,

--- a/terra/env.py
+++ b/terra/env.py
@@ -255,7 +255,6 @@ class TerraEnv(NamedTuple):
             "agent_width": state.agent.width,
             "agent_height": state.agent.height,
             "padding_mask": state.world.padding_mask.map,
-            "dig_map": state.world.dig_map.map,
             "dumpability_mask": state.world.dumpability_mask.map,
         }
 

--- a/terra/map.py
+++ b/terra/map.py
@@ -18,7 +18,6 @@ class GridWorld(NamedTuple):
         - -1: dug here during the episode
         - 0: free
         - greater than 0: dumped here
-    - dig map (same as action map but updated on the dig action & before the dump action is complete)
     - dumpability mask
         - 1: can dump
         - 0: can't dump
@@ -29,6 +28,9 @@ class GridWorld(NamedTuple):
         - -1: agent occupancy
         - 0: traversable
         - 1: non traversable
+    - last dig mask
+        - 1: dug here during previous dig action
+        - 0: not dug here during previous dig action
     - local map target positive (contains the sum of all the positive target map tiles in a given workspace)
     - local map target negative (contains the sum of all the negative target map tiles in a given workspace)
     - local map action positive (contains the sum of all the positive action map tiles in a given workspace)
@@ -42,6 +44,7 @@ class GridWorld(NamedTuple):
     padding_mask: GridMap
     dumpability_mask: GridMap
     dumpability_mask_init: GridMap
+    last_dig_mask: GridMap
 
     trench_axes: Array
     trench_type: jnp.int32  # type of trench (number of branches), or -1 if not a trench
@@ -85,6 +88,7 @@ class GridWorld(NamedTuple):
         padding_mask = GridMap.new(IntLowDim(padding_mask))
         dumpability_mask_init_gm = GridMap.new(dumpability_mask_init.astype(jnp.bool_))
         dumpability_mask = GridMap.new(dumpability_mask_init.astype(jnp.bool_))
+        last_dig_mask = GridMap.new(jnp.zeros_like(target_map.map, dtype=jnp.bool_))
 
         world = cls(
             target_map=target_map,
@@ -94,6 +98,7 @@ class GridWorld(NamedTuple):
             trench_type=trench_type,
             dumpability_mask=dumpability_mask,
             dumpability_mask_init=dumpability_mask_init_gm,
+            last_dig_mask=last_dig_mask,
         )
 
         return world

--- a/terra/map.py
+++ b/terra/map.py
@@ -40,7 +40,6 @@ class GridWorld(NamedTuple):
     target_map: GridMap
     action_map: GridMap
     padding_mask: GridMap
-    dig_map: GridMap  # map where the dig action is applied before being applied to the action map (at dump time).
     dumpability_mask: GridMap
     dumpability_mask_init: GridMap
 
@@ -82,12 +81,8 @@ class GridWorld(NamedTuple):
         dumpability_mask_init: Array,
     ) -> "GridWorld":
         action_map = GridMap.new(jnp.zeros_like(target_map, dtype=IntLowDim))
-        dig_map = GridMap.new(jnp.zeros_like(target_map, dtype=IntLowDim))
-
         target_map = GridMap.new(IntLowDim(target_map))
-
         padding_mask = GridMap.new(IntLowDim(padding_mask))
-
         dumpability_mask_init_gm = GridMap.new(dumpability_mask_init.astype(jnp.bool_))
         dumpability_mask = GridMap.new(dumpability_mask_init.astype(jnp.bool_))
 
@@ -95,7 +90,6 @@ class GridWorld(NamedTuple):
             target_map=target_map,
             action_map=action_map,
             padding_mask=padding_mask,
-            dig_map=dig_map,
             trench_axes=trench_axes,
             trench_type=trench_type,
             dumpability_mask=dumpability_mask,

--- a/terra/state.py
+++ b/terra/state.py
@@ -906,12 +906,18 @@ class State(NamedTuple):
             new_map_global_coords = new_map_global_coords.reshape(
                 self.world.target_map.map.shape
             )
+            new_dumpability_mask = self._get_new_dumpability_mask(
+                new_map_global_coords,
+            )
 
             return self._replace(
                 world=self.world._replace(
                     action_map=self.world.action_map._replace(
                         map=IntLowDim(new_map_global_coords)
-                    )
+                    ),
+                    dumpability_mask=self.world.dumpability_mask._replace(
+                        map=jnp.bool_(new_dumpability_mask),
+                    ),
                 ),
                 agent=self.agent._replace(
                     agent_state=self.agent.agent_state._replace(
@@ -955,17 +961,10 @@ class State(NamedTuple):
                 self.world.target_map.map.shape
             )
 
-            new_dumpability_mask = self._get_new_dumpability_mask(
-                new_map_global_coords,
-            )
-
             return self._replace(
                 world=self.world._replace(
                     action_map=self.world.action_map._replace(
                         map=IntLowDim(new_map_global_coords)
-                    ),
-                    dumpability_mask=self.world.dumpability_mask._replace(
-                        map=jnp.bool_(new_dumpability_mask),
                     ),
                 ),
                 agent=self.agent._replace(

--- a/terra/state.py
+++ b/terra/state.py
@@ -1146,7 +1146,7 @@ class State(NamedTuple):
             def reward_when_progress_positive():
                 return jax.lax.cond(
                     self.agent.moving_dumped_dirt,
-                    lambda: 0.2 * action_map_positive_progress * self.env_cfg.rewards.dump_correct,
+                    lambda: 0.15 * action_map_positive_progress * self.env_cfg.rewards.dump_correct,
                     lambda: action_map_positive_progress * self.env_cfg.rewards.dump_correct,
                 )
             return jax.lax.cond(

--- a/terra/state.py
+++ b/terra/state.py
@@ -831,7 +831,7 @@ class State(NamedTuple):
         cone_mask = self._build_dig_dump_cone()
         dig_map_mask = jax.lax.cond(
             (
-                self.world.last_dig_mask.reshape(-1)
+                self.world.last_dig_mask.map.reshape(-1)
                 * (self.world.action_map.map.reshape(-1) > 0)
                 * cone_mask
             ).sum()
@@ -919,7 +919,7 @@ class State(NamedTuple):
                         map=jnp.bool_(new_dumpability_mask),
                     ),
                     last_dig_mask=self.world.last_dig_mask._replace(
-                        map=jnp.bool_(dig_mask),
+                        map=jnp.bool_(dig_mask.reshape(self.world.target_map.map.shape)),
                     )
                 ),
                 agent=self.agent._replace(


### PR DESCRIPTION
This PR removes the dig map which is a pre-dumping representation of the action map and a massive data duplication. It contains the action map + information about where we just dug from. The actual action map is only updated with this information once the dumping happens. This was supposed to teach the agent that "each dig action is corresponding to a dump action" and to prevent the agent from learning to get rewards by digging and dumping the same soil over and over again but was making development difficult on other sides. Now the logic has been changed:

1. Action map is also updated after digging and dig map has been removed.
2. Rewards for digging are applied immediately.
3. Rewards for dumping are different depending on whether we are dumping "fresh" soil or previously dumped soil (to prevent the behavior mentioned above).
4. We still keep track of which tiles were just dug to allow `_exclude_just_moved_tiles_from_dump_mask()` to do its job - crucial for making the agent's live easier.


Training in progress but seems to work fine - https://wandb.ai/terra-sp-thesis/remove-dig-map?nw=nwuserstachq1