### PR TITLE
Fix edge dig bonus reward gate

### DIFF
--- a/terra/state.py
+++ b/terra/state.py
@@ -2882,8 +2882,8 @@ class State(NamedTuple):
         )
 
         # Edge-specific shaping: reward correctly dug tiles that belong to the
-        # inner foundation border band (if present). This is disabled by default
-        # via rewards.dig_edge_bonus = 0.0 to keep backward compatibility.
+        # inner foundation border band. Failed/no-op DO attempts must not receive
+        # this bonus; otherwise the policy can profit from invalid dig actions.
         old_action = self.world.action_map.map
         new_action = new_state.world.action_map.map
         target = self.world.target_map.map
@@ -2901,7 +2901,7 @@ class State(NamedTuple):
         )
         edge_bonus = jax.lax.cond(
             enforce_edge_alignment,
-            lambda: self.env_cfg.rewards.dig_edge_bonus,  #edge_dug_count *
+            lambda: edge_dug_count * self.env_cfg.rewards.dig_edge_bonus,
             lambda: jnp.float32(0.0),
         )
 


### PR DESCRIPTION
## Summary
- Fix foundation-edge dig shaping so the edge bonus is proportional to newly dug border tiles
- Prevent failed/no-op DO attempts from receiving a flat positive edge bonus

## Bug
`_handle_rewards_dig()` already computed `edge_dug_count`, but the reward path ignored it:

```python
edge_bonus = jax.lax.cond(
    enforce_edge_alignment,
    lambda: self.env_cfg.rewards.dig_edge_bonus,
    lambda: jnp.float32(0.0),
)
```

That means any unloaded `DO` action received the foundation-edge bonus whenever edge alignment was enabled, even if it dug zero edge tiles.

With the dense reward values this made an invalid/no-op unloaded `DO` net-positive:

```text
+0.8   flat dig_edge_bonus
-0.25  dig_wrong, because no useful dirt was loaded
-0.25  existence penalty
= +0.30 raw reward
/ 70 normalizer ~= +0.0043 reward
```

This matches the observed medium-deep collapse signature: reward stayed around `+0.0041` while invalid-action rate approached `~0.986`, terrain changes went near zero, completion went near zero, and success stayed zero. PPO was optimizing the reward it was given: invalid `DO` spam was profitable.

## Fix
Pay the edge bonus only for actual newly dug foundation-border tiles:

```python
lambda: edge_dug_count * self.env_cfg.rewards.dig_edge_bonus
```

After this change, a failed/no-op `DO` receives no edge bonus and is penalized by wrong-dig plus existence cost.

## Test
- `python3 -m py_compile /home/lorenzo/moleworks/terra_edge_bonus_multiagent/terra/state.py`
